### PR TITLE
Not found should return a 404 message to the caller instead of a bad …

### DIFF
--- a/domain/errs/httperrors.go
+++ b/domain/errs/httperrors.go
@@ -191,7 +191,11 @@ func otherErrorResponse(w http.ResponseWriter, lgr zerolog.Logger, err error) {
 // httpErrorStatusCode maps an error Kind to an HTTP Status Code
 func httpErrorStatusCode(k Kind) int {
 	switch k {
-	case Invalid, Exist, NotExist, Private, BrokenLink, Validation, InvalidRequest:
+	case NotExist:
+		// If the resource being requested does not exist, that should be a 404
+		return http.StatusNotFound
+
+	case Invalid, Exist, Private, BrokenLink, Validation, InvalidRequest:
 		return http.StatusBadRequest
 	// the zero value of Kind is Other, so if no Kind is present
 	// in the error, Other is used. Errors should always have a

--- a/domain/errs/httperrors_test.go
+++ b/domain/errs/httperrors_test.go
@@ -23,8 +23,8 @@ func Test_httpErrorStatusCode(t *testing.T) {
 		args args
 		want int
 	}{
+		{"NotExist", args{k: NotExist}, http.StatusNotFound},
 		{"Exist", args{k: Exist}, http.StatusBadRequest},
-		{"NotExist", args{k: NotExist}, http.StatusBadRequest},
 		{"Invalid", args{k: Invalid}, http.StatusBadRequest},
 		{"Private", args{k: Private}, http.StatusBadRequest},
 		{"BrokenLink", args{k: BrokenLink}, http.StatusBadRequest},


### PR DESCRIPTION
Right now, if a resource is not found such as
https://api.mycompany.com/v1/resource/1234
the Response code returned is a 400 or StatusBadRequest.

After doing quite a bit of looking into best practices, people expect a 404 or StatusNotFound with the additional information returned as a payload.
