### PR TITLE
Added a function to return an empty body success with a 204 code.

### DIFF
--- a/domain/errs/httperrors.go
+++ b/domain/errs/httperrors.go
@@ -58,6 +58,13 @@ func HTTPErrorResponse(w http.ResponseWriter, lgr zerolog.Logger, err error) {
 	otherErrorResponse(w, lgr, err)
 }
 
+// HTTPEmptyResponse takes a writer and a logger and writes an empty, yet
+// successful response to the client
+func HTTPEmptyResponse(w http.ResponseWriter, lgr zerolog.Logger) {
+	lgr.Debug().Int("HTTP StatusCode", http.StatusNoContent).Msg("no response body sent")
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // typicalErrorResponse replies to the request with the specified error
 // message and HTTP code. It does not otherwise end the request; the
 // caller should ensure no further writes are done to w.

--- a/domain/errs/httperrors_test.go
+++ b/domain/errs/httperrors_test.go
@@ -120,3 +120,20 @@ func TestHTTPErrorResponse_Body(t *testing.T) {
 		})
 	}
 }
+
+func TestHTTPEmptyResponse(t *testing.T) {
+
+	var b bytes.Buffer
+	l := logger.NewLogger(&b, zerolog.DebugLevel, false)
+
+	t.Run("empty response", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		HTTPEmptyResponse(w, l)
+		if w.Body != nil && w.Body.Len() != 0 {
+			t.Errorf("expected an empty body, but received [%v]", w.Body)
+		}
+		if w.Code != http.StatusNoContent {
+			t.Errorf("expected StatusNoContent, but received %v", w.Code)
+		}
+	})
+}


### PR DESCRIPTION
Rather than write a Nil response, we should not return a body and set the code to 204 indicating that there is no body being returned.

Consider curl -X DELETE v1/1234
when resource 1234 is not there.  A success return is important, but we have nothing to return, so an empty body rather than "Nil" is appropriate.